### PR TITLE
Add options.x and options.y to the constructor to allow positioning of the video instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Create, show and position a timestamp that updates with the time elapsed as the 
 
 ```coffeescript
 video.showTimeElapsed = true
-timeElapsed = video.currentTime
+timeElapsed = video.timeElapsed
 timeElapsed.x = 100
 timeElapsed.centerY(100)
 ```

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ Usually you'll want to display either time left or total time, along with the ti
 Create, show and position a timestamp that updates with the time elapsed as the video plays:
 
 ```coffeescript
-timeElapsed = video.showTimeElapsed
+video.showTimeElapsed = true
+timeElapsed = video.currentTime
 timeElapsed.x = 100
 timeElapsed.centerY(100)
 ```
@@ -140,8 +141,9 @@ timeElapsed.centerY(100)
 Create, show and position a timestamp that updates with the time left in the video:
 
 ```coffeescript
-timeLeft = video.showTimeLeft
-timeTotal.maxX = 650
+video.showTimeLeft = true 
+timeLeft = video.timeLeft
+timeLeft.maxX = 650
 timeLeft.centerY(100)
 ```
 
@@ -150,7 +152,8 @@ timeLeft.centerY(100)
 Create, show and position a static timestamp with the total duration of the video:
 
 ```coffeescript
-timeTotal = video.showTimeTotal
+video.showTimeTotal = true
+timeTotal = video.timeTotal
 timeTotal.maxX = 650
 timeTotal.centerY(100)
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The VideoPlayer module makes it simple to add a progress bar that reflects the v
 Dragging the progress bar when the video is playing should scrub the video, and dragging when it's paused should seek. That said, right now the scrubbing works great in Framer Studio but less so in the browser or on the device.
 
 ```coffeescript
-video.showProgressBar = true
+video.showProgress = true
 ```
 
 After you've created a progress bar, you'll have access to `video.progressBar` which is an instance of Framer's [SliderComponent](http://framerjs.com/docs/#slider.slidercomponent). You can of course set the dimensions and position of the progress bar:

--- a/module/videoplayer.coffee
+++ b/module/videoplayer.coffee
@@ -39,6 +39,8 @@ class exports.VideoPlayer extends Layer
     super
       width: options.width
       height: options.height
+      x: options.x
+      y: options.y
       backgroundColor: null
 
     # create the videolayer
@@ -84,7 +86,7 @@ class exports.VideoPlayer extends Layer
         for layer in @_controlsArray
           layer.animateStop()
           layer.opacity = 1
-        
+
     # event listening on the videoLayer
     Events.wrap(@videoLayer.player).on "pause", =>
       @emit "video:pause"
@@ -144,11 +146,11 @@ class exports.VideoPlayer extends Layer
     get: -> @_showTimeTotal
     set: (showTimeTotal) -> @setTimeTotal(showTimeTotal)
 
-  @define "shyPlayButton", 
+  @define "shyPlayButton",
     get: -> @_shyPlayButton
     set: (shyPlayButton) -> @setShyPlayButton(shyPlayButton)
 
-  @define "shyControls", 
+  @define "shyControls",
     get: -> @_shyControls
     set: (shyControls) -> @setShyControls(shyControls)
 
@@ -218,7 +220,7 @@ class exports.VideoPlayer extends Layer
         properties:
           opacity: 0
         time: 2
-    
+
   # show and increment elapsed time
   setTimeElapsed: (showTimeElapsed) ->
     @_showTimeElapsed = showTimeElapsed


### PR DESCRIPTION
Currently, only setting it after creation works (like this: video.y =
120 but not as a property within the constructor itself)
